### PR TITLE
QPSK modified code for Audio-OFDM

### DIFF
--- a/Audio-OFDM-QPSK-RX.m
+++ b/Audio-OFDM-QPSK-RX.m
@@ -1,6 +1,18 @@
  %%discard unwanted samples in audio file OFDM QPSK
- close all
- x=txout;
+% ofdm decoder
+clear all
+close all
+clc
+plotcrap = 1;
+
+FILTERSPEC = '.wav';
+TITLE = 'Pick a Recorded OFDM IQ wav file';
+FILE = 'D:\gnu_radio_work';
+
+[FILENAME, PATHNAME, FILTERINDEX] = uigetfile(FILTERSPEC, TITLE, FILE);
+xstring = [PATHNAME FILENAME];
+
+[x,fswav] = audioread(xstring);
  %x=x(:,1);
  if sum(x(1,:))==1
  x=x';

--- a/Audio-OFDM-QPSK-RX.m
+++ b/Audio-OFDM-QPSK-RX.m
@@ -1,0 +1,185 @@
+ %%discard unwanted samples in audio file OFDM QPSK
+ close all
+ x=txout;
+ %x=x(:,1);
+ if sum(x(1,:))==1
+ x=x';
+ end
+[xr,locr]=findpeaks(x(1:end));
+meanp = mean(xr);
+[row,colmn]=find(xr>(meanp));
+%x=x(locr(colmn(1)):locr(colmn(end)));
+x=x(locr(colmn(1)):end);
+x=x(8001:end);
+plot(x)
+
+
+ %%
+
+ xdet=[1 1];
+ Nchar = 512;  % make power of 2
+bits = Nchar * 8;
+ Nguard=512;
+N2 = bits/2;
+Nfft = N2 + 1024; %for qpsk
+Nfft = (2*Nfft)  - 1 ; 
+
+%% x = x(:,1);
+%x = x.';
+
+fswav=fs;
+
+if fswav ~= fs
+    n = gcd(fs,fswav);
+    p = fs / n;
+    q = fswav / n;
+    x = resample(x,p,q);   % resample file to expected sample rate
+end
+
+
+sigtime = Nguard + 2*Nfft + 2*Nfft + 2*Nguard;
+ plotcrap=1;
+ 
+[maxv, maxi] = max(abs(xdet));
+xstart = maxi ;
+xend = xstart + sigtime ;
+
+if plotcrap
+    figure(101)
+    xplot = abs(x) / max(abs(x));
+    xplot = 20 * log10(xplot);
+    yplot = length(xdet);
+    yplot = zeros(1,yplot);
+    yplot(maxi) = -40;
+    plot(xplot)
+    hold on
+    plot(yplot)
+    hold off
+end
+
+%%
+x = x(xstart:xend);
+a = Nguard  + round(0.8*Nfft) + 1 ;
+b = a + Nfft   - 1 ;
+xp = x(a:b);
+
+a1 =  Nguard + 2*Nfft + round(0.8*Nfft) + 1 ;
+b2 = a1 + Nfft  - 1 ;
+xd = x(a1:b2);
+
+
+
+
+
+
+
+Xp = fft(xp);
+Xp = Xp( 1:floor(end/2) );
+Xd = fft(xd);
+Xd = Xd( 1:floor(end/2) );
+
+if plotcrap
+    n = length(Xd);
+    fvec = linspace(0,fs/2,n);
+    figure(103)
+    plot(fvec,20*log10(abs(Xp)))
+    hold on
+    plot(fvec,20*log10(abs(Xd)))
+    legend('Pilot FFT', 'Data FFT');
+    hold off
+end
+
+
+
+
+
+
+
+
+
+
+det = angle(Xp ./ Xd);          % ratio to get delta phase diff
+%det = abs(det);    %only for bpsk
+
+thres = pi/2;
+
+% det = ( det <= thres) .* 1   +  (det > thres) .* 0;
+det = det(513:end);
+det = det(1:bits/2);   % bits for char  
+
+if plotcrap
+    figure(104)
+    plot(det)
+    title('demodulate phase vector')
+end
+
+
+
+%det(0<=det <= thres) = 0;
+%det(det > thres) = 1;
+
+%det(det <= thres) = 1;
+%det(det > thres) = 0;
+
+%det=pskdemod(det,4); matlab function
+det2=det;
+det3=[];
+ for rr=1:2048
+if abs(det2(rr))<pi/4
+det3(rr,:)=[0 0];
+elseif abs(pi/2-det2(rr))<pi/4
+det3(rr,:)=[0 1];
+elseif abs(det2(rr))>3
+det3(rr,:)=[1 0];
+else % abs(3*pi/2-det2(rr))<=pi/4
+det3(rr,:)=[1 1];
+end
+end
+det=det3;
+
+%%
+
+
+%%
+if plotcrap
+    figure(105)
+    plot(det)
+    title('decoded bits vector')
+end
+pause on
+
+%det=dec2bin(det)
+pause()
+%det = reshape(det,8,[]);
+%det1=[512,8];
+%for z=0:511
+   % z4=z*4+1;
+    %zz4=z4+3;
+%det1(z,:)=det(z*4+1:z*4+3);
+%end
+det = det';
+det=reshape(det,8,512);
+det=det';
+
+charmes = zeros(1,Nchar);
+w = [7:-1:0];
+w = 2.^w;
+
+
+for k = 1:Nchar/2   %for qpsk
+    x = det(k,:);
+    x = x .* w;
+    x = sum(x);
+    charmes(k) = x;
+end
+
+
+
+    clc
+
+   xstr =  char(charmes)
+
+   msgbox(xstr,'replace')
+
+
+

--- a/Audio-OFDM-QPSK.m
+++ b/Audio-OFDM-QPSK.m
@@ -1,0 +1,129 @@
+close all
+clear all
+clc
+
+fs=8000
+Nchar=512   %for qpsk
+guardN=512  
+
+%%
+%N = 6000;  %number of samples for preamble
+t = [0:7999]/fs;
+bits=Nchar*8;
+Nfft = bits/2 + 1024;   %for qpsk
+
+pream=sin(2*pi*256*t).*exp(t);
+pream = pream / max(pream);
+
+%%get message from txt file
+fid = fopen('D:\Users\Student\Desktop\0_readme.important.txt');
+mtxt = fread(fid);
+fclose(fid);
+mtxt = mtxt';
+if length(mtxt) >= Nchar
+    mtxt = mtxt(1:Nchar);
+else
+    z = length(mtxt);
+    z = Nchar - z;
+    mtxt = [mtxt zeros(1,z)];
+end
+mbits = dec2bin(mtxt,8);
+mbits = reshape(mbits',1,[]);
+mbits = mbits(1:bits);
+
+%%
+mbits=mbits';
+mbits1=mbits(1:2:4095);
+mbits2=mbits(2:2:4096);
+mbits=[mbits1,mbits2];
+%mbits=reshape(mbits,2048,2);
+ mbits=bin2dec(mbits);
+txbits = zeros(1,bits/2); %for qpsk
+
+%%
+for k = 1:bits/2 %for qpsk
+    if mbits(k) == '1'
+        txbits(k) = 1;
+    elseif mbits(k) == '2'
+         txbits(k) = 2;
+    elseif mbits(k) == '3'
+         txbits(k) = 3;
+    else
+        txbits(k) = 0;
+    end
+end
+% Above section has no effect
+
+txbits=mbits;
+
+
+
+% Perform QPSK mod
+
+ qpsk_modulated_data = pskmod(txbits, 4);
+
+qpsk_modulated_data=qpsk_modulated_data';
+qpsk_modulated_data= [zeros(1,512)   qpsk_modulated_data    zeros(1,512) ];  %512 guard on each side
+%%
+
+% make pilot vector
+xp = randn(1,Nfft);
+xp = xp / max(xp);
+xp = xp * 12;
+
+
+% pilot vector with 512 guard on each side
+xp = exp(1i*xp);
+xp(1:512) = 0;
+xp(end-511:end) = 0;
+
+% relate data vector to pilot vector
+qpsk_modulated_data = xp .* qpsk_modulated_data;  % e^a * e^b =  e^(a + b)
+
+xp1 = conj( xp(end:-1:2));
+xp = [xp1 xp];
+
+qpsk_modulated_data1 = conj(qpsk_modulated_data(end:-1:2));
+qpsk_modulated_data = [qpsk_modulated_data1 qpsk_modulated_data];
+
+
+
+td = 2;
+tdsamples = round(td * fs);
+tdvec = zeros(1,tdsamples);
+
+%%Generate random data
+     data_in=randi([0 1],2048,1);       
+   % data_in=reshape(data_in,[2048,8]);
+    data_in=reshape(data_in,[256,8]);
+    data_in(:,8)=0; %CP
+    data_in=reshape(data_in,[2048,1]);
+
+
+%%
+figure(1),stem(txbits); grid on; xlabel('Data Points'); ylabel('Amplitude')
+title('Original Data ')
+
+%%
+
+% pilot time vector
+xp = ifftshift(xp);
+xp = ifft(xp);
+xp = xp / max(abs(xp));
+
+
+%% IFFT 256 subcarriers
+
+qpsk_modulated_data=ifftshift(qpsk_modulated_data);
+ txout = ifft(qpsk_modulated_data);
+ txout = txout / max(abs(txout));
+ %txout=txout';
+xz = zeros(1,guardN);
+txout=[tdvec pream xz xp xp txout txout xz tdvec];
+%sigtime = Nguard + 2*Nfft + 2*Nfft + 2*Nguard
+
+
+
+
+    
+    

--- a/AudioOFDM8PSKRX.m
+++ b/AudioOFDM8PSKRX.m
@@ -1,6 +1,18 @@
  %%discard unwanted samples in audio file OFDM QPSK
- close all
- x=txout;
+% ofdm decoder
+clear all
+close all
+clc
+plotcrap = 1;
+
+FILTERSPEC = '.wav';
+TITLE = 'Pick a Recorded OFDM IQ wav file';
+FILE = 'D:\gnu_radio_work';
+
+[FILENAME, PATHNAME, FILTERINDEX] = uigetfile(FILTERSPEC, TITLE, FILE);
+xstring = [PATHNAME FILENAME];
+
+[x,fswav] = audioread(xstring);
  %x=x(:,1);
  if sum(x(1,:))==1
  x=x';

--- a/AudioOFDM8PSKRX.m
+++ b/AudioOFDM8PSKRX.m
@@ -1,0 +1,192 @@
+ %%discard unwanted samples in audio file OFDM QPSK
+ close all
+ x=txout;
+ %x=x(:,1);
+ if sum(x(1,:))==1
+ x=x';
+ end
+[xr,locr]=findpeaks(x(1:end));
+meanp = mean(xr);
+[row,colmn]=find(xr>(meanp));
+%x=x(locr(colmn(1)):locr(colmn(end)));
+x=x(locr(colmn(1)):end);
+x=x(8001:end);
+plot(x)
+
+
+ %%
+
+ xdet=[1 1];
+ Nchar = 1024;  % make power of 2
+bits = Nchar * 8;
+ Nguard=512;
+N2 = (bits+1)/3;
+Nfft = N2 + 1024; %for qpsk
+Nfft = (2*Nfft)  - 1 ; 
+
+%% x = x(:,1);
+%x = x.';
+
+fswav=fs;
+
+if fswav ~= fs
+    n = gcd(fs,fswav);
+    p = fs / n;
+    q = fswav / n;
+    x = resample(x,p,q);   % resample file to expected sample rate
+end
+
+
+sigtime = Nguard + 2*Nfft + 2*Nfft + 2*Nguard;
+ plotcrap=1;
+ 
+[maxv, maxi] = max(abs(xdet));
+xstart = maxi ;
+xend = xstart + sigtime ;
+
+if plotcrap
+    figure(101)
+    xplot = abs(x) / max(abs(x));
+    xplot = 20 * log10(xplot);
+    yplot = length(xdet);
+    yplot = zeros(1,yplot);
+    yplot(maxi) = -40;
+    plot(xplot)
+    hold on
+    plot(yplot)
+    hold off
+end
+
+%%
+x = x(xstart:xend);
+a = Nguard  + round(0.8*Nfft) + 1 ;
+b = a + Nfft   - 1 ;
+xp = x(a:b);
+
+a1 =  Nguard + 2*Nfft + round(0.8*Nfft) + 1 ;
+b2 = a1 + Nfft  - 1 ;
+xd = x(a1:b2);
+
+
+
+
+
+
+
+Xp = fft(xp);
+Xp = Xp( 1:floor(end/2) );
+Xd = fft(xd);
+Xd = Xd( 1:floor(end/2) );
+
+if plotcrap
+    n = length(Xd);
+    fvec = linspace(0,fs/2,n);
+    figure(103)
+    plot(fvec,20*log10(abs(Xp)))
+    hold on
+    plot(fvec,20*log10(abs(Xd)))
+    legend('Pilot FFT', 'Data FFT');
+    hold off
+end
+
+
+
+
+
+
+
+
+
+
+detect = angle(Xp ./ Xd);          % ratio to get delta phase diff
+%detect = Xp ./ Xd;          % ratio to get delta phase diff
+%detect = abs(detect);    %only for bpsk
+
+thres = pi/2;
+
+% detect = ( detect <= thres) .* 1   +  (detect > thres) .* 0;
+detect = detect(513:end);
+detect = detect(1:(bits+1)/3);   % bits for char  
+
+if plotcrap
+    figure(104)
+    plot(detect)
+    title('demodulate phase vector')
+end
+
+
+
+%detect(0<=detect <= thres) = 0;
+%detect(detect > thres) = 1;
+
+%detect(detect <= thres) = 1;
+%detect(detect > thres) = 0;
+
+%detect=pskdemod(detect,4); matlab function
+det2=detect;
+det3=[];
+ for rr=1:2731
+if abs(det2(rr))<pi/8
+det3(rr,:)=[0 0 0];
+elseif abs(pi/4-det2(rr))<pi/8
+det3(rr,:)=[0 0 1];
+elseif abs(pi/2-det2(rr))<pi/8
+det3(rr,:)=[0 1 0];
+elseif abs(3*pi/4-det2(rr))<pi/8
+det3(rr,:)=[0 1 1];
+elseif abs(det2(rr))>3
+det3(rr,:)=[1 0 0];
+elseif abs(-3*pi/4-det2(rr))<pi/8
+det3(rr,:)=[1 0 1];
+elseif abs(-pi/2-det2(rr))<pi/8
+det3(rr,:)=[1 1 0];
+else % abs(3*pi/2-det2(rr))<=pi/4
+det3(rr,:)=[1 1 1];
+end
+end
+detect=det3;
+
+%%
+
+
+%%
+if plotcrap
+    figure(105)
+    plot(detect)
+    title('decoded bits vector')
+end
+pause on
+
+%detect=dec2bin(detect)
+pause()
+%detect = reshape(detect,8,[]);
+%det1=[512,8];
+%for z=0:511
+   % z4=z*4+1;
+    %zz4=z4+3;
+%det1(z,:)=detect(z*4+1:z*4+3);
+%end
+detect = detect';
+detect=detect(:,1:2728);
+detect=reshape(detect,8,1023);
+detect=detect';
+
+charmes = zeros(1,Nchar);
+w = [7:-1:0];
+w = 2.^w;
+
+
+for k = 1:Nchar-1   %for8psk
+    x = detect(k,:);
+    x = x .* w;
+    x = sum(x);
+    charmes(k) = x;
+end
+
+
+
+    clc
+
+   xstr =  char(charmes)
+
+   msgbox(xstr,'replace')

--- a/AudioOFDM8PSKTX.m
+++ b/AudioOFDM8PSKTX.m
@@ -1,0 +1,135 @@
+close all
+clear all
+clc
+
+fs=8000
+Nchar=1024   %for psk
+guardN=512  
+
+%%
+%N = 6000;  %number of samples for preamble
+t = [0:7999]/fs;
+bits=Nchar*8;
+Nfft = (bits+1)/3 + 1024;   %for 8psk
+
+pream=sin(2*pi*256*t).*exp(t);
+pream = pream / max(pream);
+
+%%get message from txt file
+fid = fopen('D:\Users\Student\Desktop\0_readme.important.txt');
+mtxt = fread(fid);
+fclose(fid);
+mtxt = mtxt';
+if length(mtxt) >= Nchar
+    mtxt = mtxt(1:Nchar);
+else
+    z = length(mtxt);
+    z = Nchar - z;
+    mtxt = [mtxt zeros(1,z)];
+end
+mbits = dec2bin(mtxt,8);
+mbits = reshape(mbits',1,[]);
+mbits = mbits(1:bits);
+mbits=[mbits 0];     %for 8psk
+
+%%
+mbits=mbits';
+mbits1=mbits(1:3:8191);
+mbits2=mbits(2:3:8192);
+mbits3=mbits(3:3:8193);
+mbits=[mbits1,mbits2,mbits3];
+%mbits=reshape(mbits,2048,2);
+ mbits=bin2dec(mbits);
+txbits = zeros(1,bits/2); %for qpsk
+
+%%
+for k = 1:(bits+1)/3 %for 8psk
+    if mbits(k) == '1'
+        txbits(k) = 1;
+    elseif mbits(k) == '2'
+         txbits(k) = 2;
+    elseif mbits(k) == '3'
+         txbits(k) = 3;
+          elseif mbits(k) == '4'
+         txbits(k) = 4;
+          elseif mbits(k) == '5'
+         txbits(k) = 5;
+          elseif mbits(k) == '6'
+         txbits(k) = 6;
+          elseif mbits(k) == '7'
+         txbits(k) = 7;
+    else
+        txbits(k) = 0;
+    end
+end
+% Above section has no effect
+
+txbits=mbits;
+
+
+
+% Perform psk mod
+psk_modulated_data = pskmod(txbits, 8);
+
+psk_modulated_data=psk_modulated_data';
+psk_modulated_data= [zeros(1,512)   psk_modulated_data    zeros(1,512) ];  %512 guard on each side
+%%
+
+% make pilot vector
+xp = randn(1,Nfft);
+xp = xp / max(xp);
+xp = xp * 12;
+
+
+% pilot vector with 512 guard on each side
+xp = exp(1i*xp);
+xp(1:512) = 0;
+xp(end-511:end) = 0;
+
+% relate data vector to pilot vector
+psk_modulated_data = xp .* psk_modulated_data;  % e^a * e^b =  e^(a + b)
+
+xp1 = conj( xp(end:-1:2));
+xp = [xp1 xp];
+
+psk_modulated_data1 = conj(psk_modulated_data(end:-1:2));
+psk_modulated_data = [psk_modulated_data1 psk_modulated_data];
+
+
+
+td = 2;
+tdsamples = round(td * fs);
+tdvec = zeros(1,tdsamples);
+
+%%Generate random data
+     data_in=randi([0 1],2048,1);       
+   % data_in=reshape(data_in,[2048,8]);
+    data_in=reshape(data_in,[256,8]);
+    data_in(:,8)=0; %CP
+    data_in=reshape(data_in,[2048,1]);
+
+
+%%
+figure(1),stem(txbits); grid on; xlabel('Data Points'); ylabel('Amplitude')
+title('Original Data ')
+
+%%
+
+% pilot time vector
+xp = ifftshift(xp);
+xp = ifft(xp);
+xp = xp / max(abs(xp));
+
+
+%% IFFT 256 subcarriers
+
+psk_modulated_data=ifftshift(psk_modulated_data);
+ txout = ifft(psk_modulated_data);
+ txout = txout / max(abs(txout));
+ %txout=txout';
+xz = zeros(1,guardN);
+txout=[tdvec pream xz xp xp txout txout xz tdvec];
+%sigtime = Nguard + 2*Nfft + 2*Nfft + 2*Nguard
+
+
+


### PR DESCRIPTION
Modified the orogonal code to be able to do 512 characters using QPSK modulation on the subcarriers.  A different technique is employed for block synchronisation in the receiver but original method could be reverted to if preferred.